### PR TITLE
feat: 담당자/작업자 할당 기능 구현

### DIFF
--- a/src/main/java/com/capston_design/fkiller/itoms/ticket_core/controller/AssignmentCallbackController.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/ticket_core/controller/AssignmentCallbackController.java
@@ -1,0 +1,20 @@
+package com.capston_design.fkiller.itoms.ticket_core.controller;
+import com.capston_design.fkiller.itoms.ticket_core.controller.dto.request.AssignmentCallbackDTO;
+import com.capston_design.fkiller.itoms.ticket_core.service.TicketAssignmentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/callback")
+@RequiredArgsConstructor
+public class AssignmentCallbackController
+{
+    private final TicketAssignmentService ticketAssignmentService;
+
+    @PostMapping("/assign-handler")
+    public ResponseEntity<Void> handleAssigneeUpdate(@RequestBody AssignmentCallbackDTO dto) {
+        ticketAssignmentService.assignHandler(dto);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/ticket_core/controller/TicketController.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/ticket_core/controller/TicketController.java
@@ -1,12 +1,11 @@
 package com.capston_design.fkiller.itoms.ticket_core.controller;
 
+import com.capston_design.fkiller.itoms.ticket_core.controller.dto.request.AssignAcceptorRequestDTO;
 import com.capston_design.fkiller.itoms.ticket_core.controller.dto.request.CreateTicketRequestDTO;
 import com.capston_design.fkiller.itoms.ticket_core.controller.dto.response.CreateTicketResponseDTO;
 import com.capston_design.fkiller.itoms.ticket_core.service.TicketService;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
@@ -25,5 +24,13 @@ public class TicketController {
     public CreateTicketResponseDTO createTicket(@RequestBody CreateTicketRequestDTO request) {
         UUID ticketId = ticketService.createTicket(request);
         return new CreateTicketResponseDTO(ticketId);
+    }
+    @PatchMapping("/v1/ticket/{id}/assign")
+    public ResponseEntity<Void> assignAcceptor(
+            @PathVariable UUID id,
+            @RequestBody AssignAcceptorRequestDTO request
+    ) {
+        ticketService.assignAcceptor(id, request);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/capston_design/fkiller/itoms/ticket_core/controller/dto/request/AssignAcceptorRequestDTO.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/ticket_core/controller/dto/request/AssignAcceptorRequestDTO.java
@@ -1,0 +1,8 @@
+package com.capston_design.fkiller.itoms.ticket_core.controller.dto.request;
+import lombok.Getter;
+
+@Getter
+public class AssignAcceptorRequestDTO {
+    private String acceptorId;
+    private String acceptorName;
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/ticket_core/controller/dto/request/AssignmentCallbackDTO.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/ticket_core/controller/dto/request/AssignmentCallbackDTO.java
@@ -1,0 +1,13 @@
+package com.capston_design.fkiller.itoms.ticket_core.controller.dto.request;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+public class AssignmentCallbackDTO {
+    private UUID ticketId;
+    private String creatorId;
+    private String creatorName;
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/ticket_core/domain/entity/Ticket.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/ticket_core/domain/entity/Ticket.java
@@ -115,4 +115,8 @@ public class Ticket extends BaseEntity {
         this.creatorId = creatorId;
         this.creatorName = creatorName;
     }
+    public void updateAcceptor(String acceptorId, String acceptorName) {
+        this.acceptorId = acceptorId;
+        this.acceptorName = acceptorName;
+    }
 }

--- a/src/main/java/com/capston_design/fkiller/itoms/ticket_core/domain/entity/Ticket.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/ticket_core/domain/entity/Ticket.java
@@ -111,4 +111,8 @@ public class Ticket extends BaseEntity {
         this.ticketStatus = ticketStatus;
         this.ticketStatusCode = ticketStatus.getCode();
     }
+    public void updateCreator(String assigneeId, String assigneeName) {
+        this.acceptorId = assigneeId;
+        this.acceptorName = assigneeName;
+    }
 }

--- a/src/main/java/com/capston_design/fkiller/itoms/ticket_core/domain/entity/Ticket.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/ticket_core/domain/entity/Ticket.java
@@ -111,8 +111,8 @@ public class Ticket extends BaseEntity {
         this.ticketStatus = ticketStatus;
         this.ticketStatusCode = ticketStatus.getCode();
     }
-    public void updateCreator(String assigneeId, String assigneeName) {
-        this.acceptorId = assigneeId;
-        this.acceptorName = assigneeName;
+    public void updateCreator(String creatorId, String creatorName) {
+        this.creatorId = creatorId;
+        this.creatorName = creatorName;
     }
 }

--- a/src/main/java/com/capston_design/fkiller/itoms/ticket_core/service/TicketAssignmentService.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/ticket_core/service/TicketAssignmentService.java
@@ -1,0 +1,26 @@
+package com.capston_design.fkiller.itoms.ticket_core.service;
+import com.capston_design.fkiller.itoms.ticket_core.controller.dto.request.AssignmentCallbackDTO;
+import com.capston_design.fkiller.itoms.ticket_core.domain.entity.Ticket;
+import com.capston_design.fkiller.itoms.ticket_core.repository.TicketRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class TicketAssignmentService {
+
+    private final TicketRepository ticketRepository;
+
+    public void assignHandler(AssignmentCallbackDTO dto) {
+        UUID ticketId = dto.getTicketId();
+
+        Ticket ticket = ticketRepository.findById(ticketId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 티켓을 찾을 수 없습니다."));
+
+        ticket.updateCreator(dto.getCreatorId(), dto.getCreatorName());
+
+        ticketRepository.save(ticket);
+    }
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/ticket_core/service/TicketService.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/ticket_core/service/TicketService.java
@@ -1,5 +1,6 @@
 package com.capston_design.fkiller.itoms.ticket_core.service;
 
+import com.capston_design.fkiller.itoms.ticket_core.controller.dto.request.AssignAcceptorRequestDTO;
 import com.capston_design.fkiller.itoms.ticket_core.controller.dto.request.CreateTicketRequestDTO;
 import com.capston_design.fkiller.itoms.ticket_core.domain.entity.Ticket;
 import com.capston_design.fkiller.itoms.ticket_core.domain.entity.TicketStatus;
@@ -31,7 +32,12 @@ public class TicketService {
 
         return ticketRepository.save(initTicket).getId();
     }
+    @Transactional
+    public void assignAcceptor(UUID ticketId, AssignAcceptorRequestDTO dto) {
+        Ticket ticket = ticketRepository.findById(ticketId)
+                .orElseThrow(() -> new IllegalArgumentException("티켓을 찾을 수 없습니다."));
 
-
-
+        ticket.updateAcceptor(dto.getAcceptorId(), dto.getAcceptorName());
+        ticketRepository.save(ticket);
+    }
 }


### PR DESCRIPTION
### 담당자/작업자 할당 기능 구현
1️⃣ **담당자(creator) 할당**
담당자 할당 서비스 -> 티켓 코어 서비스: 콜백 url을 통해 자동 할당된 담당자 정보(creatorId, creatorName) 전달 시 티켓 DB에 담당자 저장
2️⃣ **작업자(acceptor) 할당**
담당자가 할당되고, 해당 담당자가 작업자를 할당하면 티켓 DB에 작업자 정보(acceptorId, acceptorName) 저장