### PR TITLE
feat:티켓 내용 업데이트 로직

### DIFF
--- a/src/main/java/com/capston_design/fkiller/itoms/ticket_core/common/ticket_status/aspect/UpdateTicketStatusAspect.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/ticket_core/common/ticket_status/aspect/UpdateTicketStatusAspect.java
@@ -34,8 +34,8 @@ public class UpdateTicketStatusAspect {
         if(updateTicketStatus.taskNotification()){
             Ticket ticket = (Ticket) result;
             ticket.updateTicketStatus(updateTicketStatus.ticketStatus());
+            statusHolder.remove();
         }
-        statusHolder.remove();
     }
 
     public static TicketStatus getStatus() {

--- a/src/main/java/com/capston_design/fkiller/itoms/ticket_core/controller/TicketController.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/ticket_core/controller/TicketController.java
@@ -2,7 +2,7 @@ package com.capston_design.fkiller.itoms.ticket_core.controller;
 
 import com.capston_design.fkiller.itoms.ticket_core.controller.dto.request.AssignAcceptorRequestDTO;
 import com.capston_design.fkiller.itoms.ticket_core.controller.dto.request.CreateTicketRequestDTO;
-import com.capston_design.fkiller.itoms.ticket_core.controller.dto.request.UpdateTicketRequestDTO;
+import com.capston_design.fkiller.itoms.ticket_core.controller.dto.request.UpdateTicketInfoRequestDTO;
 import com.capston_design.fkiller.itoms.ticket_core.controller.dto.response.CreateTicketResponseDTO;
 import com.capston_design.fkiller.itoms.ticket_core.service.TicketService;
 import org.springframework.http.ResponseEntity;
@@ -26,7 +26,7 @@ public class TicketController {
         UUID ticketId = ticketService.createTicket(request);
         return new CreateTicketResponseDTO(ticketId);
     }
-    @PatchMapping("/v1/ticket/{id}/assign")
+    @PatchMapping("/v1/ticket/{ticketId}/assign")
     public ResponseEntity<Void> assignAcceptor(
             @PathVariable UUID id,
             @RequestBody AssignAcceptorRequestDTO request
@@ -34,12 +34,12 @@ public class TicketController {
         ticketService.assignAcceptor(id, request);
         return ResponseEntity.ok().build();
     }
-    @PatchMapping("/v1/ticket/{id}")
+    @PatchMapping("/v1/ticket/{ticketId}")
     public ResponseEntity<Void> updateTicket(
             @PathVariable UUID id,
-            @RequestBody UpdateTicketRequestDTO request
+            @RequestBody UpdateTicketInfoRequestDTO request
     ) {
-        ticketService.updateTicket(id, request);
+        ticketService.updateTicketInfo(id, request);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/capston_design/fkiller/itoms/ticket_core/controller/TicketController.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/ticket_core/controller/TicketController.java
@@ -2,6 +2,7 @@ package com.capston_design.fkiller.itoms.ticket_core.controller;
 
 import com.capston_design.fkiller.itoms.ticket_core.controller.dto.request.AssignAcceptorRequestDTO;
 import com.capston_design.fkiller.itoms.ticket_core.controller.dto.request.CreateTicketRequestDTO;
+import com.capston_design.fkiller.itoms.ticket_core.controller.dto.request.UpdateTicketRequestDTO;
 import com.capston_design.fkiller.itoms.ticket_core.controller.dto.response.CreateTicketResponseDTO;
 import com.capston_design.fkiller.itoms.ticket_core.service.TicketService;
 import org.springframework.http.ResponseEntity;
@@ -31,6 +32,14 @@ public class TicketController {
             @RequestBody AssignAcceptorRequestDTO request
     ) {
         ticketService.assignAcceptor(id, request);
+        return ResponseEntity.ok().build();
+    }
+    @PatchMapping("/v1/ticket/{id}")
+    public ResponseEntity<Void> updateTicket(
+            @PathVariable UUID id,
+            @RequestBody UpdateTicketRequestDTO request
+    ) {
+        ticketService.updateTicket(id, request);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/capston_design/fkiller/itoms/ticket_core/controller/dto/request/UpdateTicketInfoRequestDTO.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/ticket_core/controller/dto/request/UpdateTicketInfoRequestDTO.java
@@ -3,7 +3,7 @@ package com.capston_design.fkiller.itoms.ticket_core.controller.dto.request;
 import lombok.Getter;
 
 @Getter
-public class UpdateTicketRequestDTO {
+public class UpdateTicketInfoRequestDTO {
     private String ticketName;
     private String ticketContent;
 }

--- a/src/main/java/com/capston_design/fkiller/itoms/ticket_core/controller/dto/request/UpdateTicketRequestDTO.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/ticket_core/controller/dto/request/UpdateTicketRequestDTO.java
@@ -1,0 +1,9 @@
+package com.capston_design.fkiller.itoms.ticket_core.controller.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateTicketRequestDTO {
+    private String ticketName;
+    private String ticketContent;
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/ticket_core/domain/entity/Ticket.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/ticket_core/domain/entity/Ticket.java
@@ -117,4 +117,8 @@ public class Ticket extends BaseEntity {
         this.acceptorId = acceptorId;
         this.acceptorName = acceptorName;
     }
+    public void updateTicket(String name, String content) {
+        this.ticketName = name;
+        this.ticketContent = content;
+    }
 }

--- a/src/main/java/com/capston_design/fkiller/itoms/ticket_core/domain/entity/Ticket.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/ticket_core/domain/entity/Ticket.java
@@ -117,7 +117,7 @@ public class Ticket extends BaseEntity {
         this.acceptorId = acceptorId;
         this.acceptorName = acceptorName;
     }
-    public void updateTicket(String name, String content) {
+    public void updateTicketInfo(String name, String content) {
         this.ticketName = name;
         this.ticketContent = content;
     }

--- a/src/main/java/com/capston_design/fkiller/itoms/ticket_core/service/TicketService.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/ticket_core/service/TicketService.java
@@ -1,10 +1,7 @@
 package com.capston_design.fkiller.itoms.ticket_core.service;
 
-import com.capston_design.fkiller.itoms.ticket_core.controller.dto.request.AssignAcceptorRequestDTO;
+import com.capston_design.fkiller.itoms.ticket_core.controller.dto.request.*;
 import com.capston_design.fkiller.itoms.ticket_core.common.ticket_status.annotation.UpdateTicketStatus;
-import com.capston_design.fkiller.itoms.ticket_core.controller.dto.request.AssignmentCallbackDTO;
-import com.capston_design.fkiller.itoms.ticket_core.controller.dto.request.CreateTicketRequestDTO;
-import com.capston_design.fkiller.itoms.ticket_core.controller.dto.request.completeTaskRequestDTO;
 import com.capston_design.fkiller.itoms.ticket_core.domain.entity.Ticket;
 import com.capston_design.fkiller.itoms.ticket_core.domain.entity.TicketStatus;
 import com.capston_design.fkiller.itoms.ticket_core.repository.TicketRepository;
@@ -72,5 +69,14 @@ public class TicketService {
         return ticketRepository.findById(request.getTicketId())
                 .orElseThrow(() -> createBaseExceptionWithoutDetail(HttpStatus.BAD_REQUEST,
                         "유효하지 않은 티켓을 요청하였습니다"));
+    }
+    // Todo: Status 추가
+    @Transactional
+    public void updateTicket(UUID ticketId, UpdateTicketRequestDTO request) {
+        Ticket ticket = ticketRepository.findById(ticketId)
+                .orElseThrow(() -> createBaseExceptionWithoutDetail(HttpStatus.BAD_REQUEST,
+                        "유효하지 않은 티켓을 요청하였습니다"));
+        ticket.updateTicket(request.getTicketName(), request.getTicketContent());
+        ticketRepository.save(ticket);
     }
 }

--- a/src/main/java/com/capston_design/fkiller/itoms/ticket_core/service/TicketService.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/ticket_core/service/TicketService.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
-import java.util.logging.Logger;
 
 import static com.capston_design.fkiller.itoms.ticket_core.common.exception.BaseException.createBaseExceptionWithoutDetail;
 
@@ -72,11 +71,11 @@ public class TicketService {
     }
     // Todo: Status 추가
     @Transactional
-    public void updateTicket(UUID ticketId, UpdateTicketRequestDTO request) {
+    public void updateTicketInfo(UUID ticketId, UpdateTicketInfoRequestDTO request) {
         Ticket ticket = ticketRepository.findById(ticketId)
                 .orElseThrow(() -> createBaseExceptionWithoutDetail(HttpStatus.BAD_REQUEST,
                         "유효하지 않은 티켓을 요청하였습니다"));
-        ticket.updateTicket(request.getTicketName(), request.getTicketContent());
+        ticket.updateTicketInfo(request.getTicketName(), request.getTicketContent());
         ticketRepository.save(ticket);
     }
 }


### PR DESCRIPTION
담당자 Client -> 티켓 코어 -> 티켓 코어 DB에 티켓 문의 내용 업데이트

🧐 **추가 고려사항**
Status 저장할 때 로깅용이랑 사용자한테 보여주는 Status랑 구분 안해도 될지