### PR TITLE
feat:SRM에서 티켓 조회 시 티켓 리스트 반환 기능

### DIFF
--- a/src/main/java/com/capston_design/fkiller/itoms/ticket_core/controller/TicketController.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/ticket_core/controller/TicketController.java
@@ -2,13 +2,16 @@ package com.capston_design.fkiller.itoms.ticket_core.controller;
 
 import com.capston_design.fkiller.itoms.ticket_core.controller.dto.request.AssignAcceptorRequestDTO;
 import com.capston_design.fkiller.itoms.ticket_core.controller.dto.request.CreateTicketRequestDTO;
+import com.capston_design.fkiller.itoms.ticket_core.controller.dto.request.TicketInfoRequestDTO;
 import com.capston_design.fkiller.itoms.ticket_core.controller.dto.request.UpdateTicketInfoRequestDTO;
 import com.capston_design.fkiller.itoms.ticket_core.controller.dto.response.CreateTicketResponseDTO;
+import com.capston_design.fkiller.itoms.ticket_core.controller.dto.response.TicketInfoResponseDTO;
 import com.capston_design.fkiller.itoms.ticket_core.service.TicketService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -40,5 +43,19 @@ public class TicketController {
         ticketService.updateTicketInfo(ticketId, request);
         return ResponseEntity.ok().build();
     }
+    @GetMapping("/v1/tickets")
+    public ResponseEntity<List<TicketInfoResponseDTO>> getTicketsByAcceptor(
+            @RequestParam("acceptorId") String acceptorId) {
 
+        List<TicketInfoResponseDTO> tickets = ticketService.findByAcceptorId(acceptorId);
+        return ResponseEntity.ok(tickets);
+    }
+
+    @PostMapping("/v1/assigned")
+    public ResponseEntity<List<TicketInfoResponseDTO>> getTicketsByChargerId(
+            @RequestBody TicketInfoRequestDTO request) {
+
+        List<TicketInfoResponseDTO> tickets = ticketService.findByAcceptorId(request.getChargerId());
+        return ResponseEntity.ok(tickets);
+    }
 }

--- a/src/main/java/com/capston_design/fkiller/itoms/ticket_core/controller/TicketController.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/ticket_core/controller/TicketController.java
@@ -43,19 +43,10 @@ public class TicketController {
         ticketService.updateTicketInfo(ticketId, request);
         return ResponseEntity.ok().build();
     }
-    @GetMapping("/v1/acceptorId")
-    public ResponseEntity<List<TicketInfoResponseDTO>> getTicketsByAcceptor(
-            @RequestParam("acceptorId") String acceptorId) {
-
-        List<TicketInfoResponseDTO> tickets = ticketService.findByAcceptorId(acceptorId);
-        return ResponseEntity.ok(tickets);
-    }
-
-    @PostMapping("/v1/assigned")
-    public ResponseEntity<List<TicketInfoResponseDTO>> getTicketsByChargerId(
+    @PostMapping("v1/tickets/by-acceptor")
+    public ResponseEntity<List<TicketInfoResponseDTO>> getTicketsByAcceptorId(
             @RequestBody TicketInfoRequestDTO request) {
-
-        List<TicketInfoResponseDTO> tickets = ticketService.findByAcceptorId(request.getChargerId());
+        List<TicketInfoResponseDTO> tickets = ticketService.findTicketsByAcceptorId(request.getAcceptorId());
         return ResponseEntity.ok(tickets);
     }
 }

--- a/src/main/java/com/capston_design/fkiller/itoms/ticket_core/controller/TicketController.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/ticket_core/controller/TicketController.java
@@ -43,7 +43,7 @@ public class TicketController {
         ticketService.updateTicketInfo(ticketId, request);
         return ResponseEntity.ok().build();
     }
-    @GetMapping("/v1/tickets")
+    @GetMapping("/v1/acceptorId")
     public ResponseEntity<List<TicketInfoResponseDTO>> getTicketsByAcceptor(
             @RequestParam("acceptorId") String acceptorId) {
 

--- a/src/main/java/com/capston_design/fkiller/itoms/ticket_core/controller/dto/request/TicketInfoRequestDTO.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/ticket_core/controller/dto/request/TicketInfoRequestDTO.java
@@ -1,0 +1,9 @@
+package com.capston_design.fkiller.itoms.ticket_core.controller.dto.request;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TicketInfoRequestDTO {
+    private String chargerId;
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/ticket_core/controller/dto/request/TicketInfoRequestDTO.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/ticket_core/controller/dto/request/TicketInfoRequestDTO.java
@@ -5,5 +5,5 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class TicketInfoRequestDTO {
-    private String chargerId;
+    private String acceptorId;
 }

--- a/src/main/java/com/capston_design/fkiller/itoms/ticket_core/controller/dto/response/TicketInfoResponseDTO.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/ticket_core/controller/dto/response/TicketInfoResponseDTO.java
@@ -1,0 +1,46 @@
+package com.capston_design.fkiller.itoms.ticket_core.controller.dto.response;
+
+import com.capston_design.fkiller.itoms.ticket_core.domain.entity.Ticket;
+import com.capston_design.fkiller.itoms.ticket_core.domain.entity.TicketStatus;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class TicketInfoResponseDTO {
+    private String incidentId;
+    private UUID ticketId;
+    private String creatorId;
+    private String creatorName;
+    private String acceptorId;
+    private String acceptorName;
+    private LocalDateTime ticketPlanStartDate;
+    private LocalDateTime ticketPlanDuration;
+    private String ticketName;
+    private String ticketContent;
+    private TicketStatus ticketStatus;
+
+    public static TicketInfoResponseDTO from(Ticket ticket) {
+        return TicketInfoResponseDTO.builder()
+                .incidentId(ticket.getIncidentId())
+                .ticketId(ticket.getId())
+                .creatorId(ticket.getCreatorId())
+                .creatorName(ticket.getCreatorName())
+                .acceptorId(ticket.getAcceptorId())
+                .acceptorName(ticket.getAcceptorName())
+                .ticketPlanStartDate(ticket.getTicketPlanStartDate())
+                .ticketPlanDuration(ticket.getTicketPlanDuration())
+                .ticketName(ticket.getTicketName())
+                .ticketContent(ticket.getTicketContent())
+                .ticketStatus(ticket.getTicketStatus())
+                .build();
+    }
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/ticket_core/domain/entity/Ticket.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/ticket_core/domain/entity/Ticket.java
@@ -44,7 +44,7 @@ public class Ticket extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private TicketStatus ticketStatus;
 
-    @Column(name = "ticket_tatus_code", nullable = false)
+    @Column(name = "ticket_status_code", nullable = false)
     private int ticketStatusCode;
 
     @Column(name = "ticket_name")

--- a/src/main/java/com/capston_design/fkiller/itoms/ticket_core/repository/TicketRepository.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/ticket_core/repository/TicketRepository.java
@@ -3,7 +3,9 @@ package com.capston_design.fkiller.itoms.ticket_core.repository;
 import com.capston_design.fkiller.itoms.ticket_core.domain.entity.Ticket;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface TicketRepository extends JpaRepository<Ticket, UUID> {
+    List<Ticket> findByAcceptorId(String acceptorId);;
 }

--- a/src/main/java/com/capston_design/fkiller/itoms/ticket_core/repository/TicketRepository.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/ticket_core/repository/TicketRepository.java
@@ -7,5 +7,5 @@ import java.util.List;
 import java.util.UUID;
 
 public interface TicketRepository extends JpaRepository<Ticket, UUID> {
-    List<Ticket> findByAcceptorId(String acceptorId);;
+    List<Ticket> findTicketsByAcceptorId(String acceptorId);;
 }

--- a/src/main/java/com/capston_design/fkiller/itoms/ticket_core/service/TicketService.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/ticket_core/service/TicketService.java
@@ -69,8 +69,8 @@ public class TicketService {
         ticketRepository.save(ticket);
     }
 
-    public List<TicketInfoResponseDTO> findByAcceptorId(String acceptorId) {
-        List<Ticket> tickets = ticketRepository.findByAcceptorId(acceptorId);
+    public List<TicketInfoResponseDTO> findTicketsByAcceptorId(String acceptorId) {
+        List<Ticket> tickets = ticketRepository.findTicketsByAcceptorId(acceptorId);
         return tickets.stream()
                 .map(TicketInfoResponseDTO::from)
                 .collect(Collectors.toList());

--- a/src/main/java/com/capston_design/fkiller/itoms/ticket_core/service/TicketService.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/ticket_core/service/TicketService.java
@@ -2,6 +2,7 @@ package com.capston_design.fkiller.itoms.ticket_core.service;
 
 import com.capston_design.fkiller.itoms.ticket_core.controller.dto.request.*;
 import com.capston_design.fkiller.itoms.ticket_core.common.ticket_status.annotation.UpdateTicketStatus;
+import com.capston_design.fkiller.itoms.ticket_core.controller.dto.response.TicketInfoResponseDTO;
 import com.capston_design.fkiller.itoms.ticket_core.domain.entity.Ticket;
 import com.capston_design.fkiller.itoms.ticket_core.domain.entity.TicketStatus;
 import com.capston_design.fkiller.itoms.ticket_core.repository.TicketRepository;
@@ -11,7 +12,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static com.capston_design.fkiller.itoms.ticket_core.common.exception.BaseException.createBaseExceptionWithoutDetail;
 
@@ -64,5 +67,12 @@ public class TicketService {
                         "유효하지 않은 티켓을 요청하였습니다"));
         ticket.updateTicketInfo(request.getTicketName(), request.getTicketContent());
         ticketRepository.save(ticket);
+    }
+
+    public List<TicketInfoResponseDTO> findByAcceptorId(String acceptorId) {
+        List<Ticket> tickets = ticketRepository.findByAcceptorId(acceptorId);
+        return tickets.stream()
+                .map(TicketInfoResponseDTO::from)
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
🧑‍💻 **PR요약**
POST /api/ticket-core/v1/tickets/by-acceptor
api를 통해 requestbody로 작업자 ID 받아옴

✅ **변경사항 요약**
- TicketController: GET/POST 방식 API 엔드포인트 구현

- TicketService: 티켓 조회 비즈니스 로직 구현

- TicketRepository: acceptorId 기반 조회 쿼리 추가

- DTO: TicketInfoResponseDTO, TicketInfoRequestDTO 생성