### PR TITLE
FK-67 티켓 생성 시 임시 담당자 할당

### DIFF
--- a/src/main/java/com/capston_design/fkiller/itoms/ticket_core/client/UserServiceClient.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/ticket_core/client/UserServiceClient.java
@@ -1,0 +1,14 @@
+package com.capston_design.fkiller.itoms.ticket_core.client;
+
+import com.capston_design.fkiller.itoms.ticket_core.client.dto.response.CommonResponse;
+import com.capston_design.fkiller.itoms.ticket_core.client.dto.response.CreatorInfoResponseDTO;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@FeignClient(name = "user-service", url = "http://localhost:8083/api/user")
+public interface UserServiceClient {
+
+    @GetMapping("/randomCreator")
+    CommonResponse<CreatorInfoResponseDTO> getRandomCreatorInfo();
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/ticket_core/client/dto/response/CommonResponse.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/ticket_core/client/dto/response/CommonResponse.java
@@ -1,0 +1,13 @@
+package com.capston_design.fkiller.itoms.ticket_core.client.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class CommonResponse<T> {
+    private boolean isSuccess;
+    private String code;
+    private String message;
+    private T result;
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/ticket_core/client/dto/response/CreatorInfoResponseDTO.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/ticket_core/client/dto/response/CreatorInfoResponseDTO.java
@@ -1,0 +1,12 @@
+package com.capston_design.fkiller.itoms.ticket_core.client.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class CreatorInfoResponseDTO {
+    private String id;
+    private String name;
+    private String category;
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/ticket_core/domain/entity/Ticket.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/ticket_core/domain/entity/Ticket.java
@@ -75,7 +75,7 @@ public class Ticket extends BaseEntity {
     private String acceptorName;
 
     @Builder(toBuilder = true)
-    public Ticket(UUID incidentId, boolean isDeleted, String closedAt, LocalDateTime acceptedAt, LocalDateTime ticketPlanStartDate,
+    public Ticket(UUID incidentId, boolean isDeleted, LocalDateTime closedAt, LocalDateTime acceptedAt, LocalDateTime ticketPlanStartDate,
                   LocalDateTime ticketPlanEndDate, LocalDateTime ticketPlanDuration, TicketStatus ticketStatus,
                   int ticketStatusCode, String ticketName, String ticketContent, boolean ticketActive, String creatorId,
                   String creatorName, String requesterId, String requesterName, String acceptorId, String acceptorName) {

--- a/src/main/java/com/capston_design/fkiller/itoms/ticket_core/service/TicketService.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/ticket_core/service/TicketService.java
@@ -1,5 +1,8 @@
 package com.capston_design.fkiller.itoms.ticket_core.service;
 
+import com.capston_design.fkiller.itoms.ticket_core.client.IncidentClient;
+import com.capston_design.fkiller.itoms.ticket_core.client.UserServiceClient;
+import com.capston_design.fkiller.itoms.ticket_core.client.dto.response.CreatorInfoResponseDTO;
 import com.capston_design.fkiller.itoms.ticket_core.common.util.ClockUtils;
 import com.capston_design.fkiller.itoms.ticket_core.controller.dto.request.*;
 import com.capston_design.fkiller.itoms.ticket_core.common.ticket_status.annotation.UpdateTicketStatus;
@@ -29,6 +32,7 @@ public class TicketService {
 
     private final RestTicketEventListener restTicketEventListener;
     private final TicketRepository ticketRepository;
+    private final UserServiceClient userServiceClient;
 
     @UpdateTicketStatus(ticketStatus = TicketStatus.REQUEST_CREATE_TICKET)
     @Transactional
@@ -37,8 +41,11 @@ public class TicketService {
         Ticket initTicket = Ticket.ofCreateBaseTicket(request.getIncidentId(),
                 request.getRequester().getRequesterId(),
                 request.getRequester().getRequesterName());
-        //TODO: AI에 Creator 할당 요청
-        //TODO: random Creator ID 할당 요청
+
+        // 임시로 담당자 랜덤 할당 -> 이후에 모델에게 요청하는 로직으로 변경
+        CreatorInfoResponseDTO randomCreatorInfo = userServiceClient.getRandomCreatorInfo().getResult();
+        initTicket.updateCreator(randomCreatorInfo.getId(), randomCreatorInfo.getName());
+
         return ticketRepository.save(initTicket).getId();
     }
 


### PR DESCRIPTION
userService에 랜덤 담당자 할당 요청 보낸 후 ticket 엔티티 생성하여 id 반환하는 구조

⚙️ 고려사항
- 이후 해당 부분은 모델 요청 방식으로 변경 예정
- url 환경 변수화 필요